### PR TITLE
Update API base URL and add allowed CORS origin

### DIFF
--- a/client/src/context/api.js
+++ b/client/src/context/api.js
@@ -7,8 +7,15 @@ import axios from 'axios';
 //   },
 // });
 
+//const api = axios.create({
+//  baseURL: "http://localhost/api",
+//  headers: {
+//    "Content-Type": "application/json",
+//  }
+//})
+
 const api = axios.create({
-  baseURL: "http://localhost/api",
+  baseURL: "https://dulharakaushalya-research-assistant-for-pdfs.hf.space",
   headers: {
     "Content-Type": "application/json",
   }

--- a/server/api/main.py
+++ b/server/api/main.py
@@ -13,6 +13,7 @@ from server.utils.config import DOTENV_PATH, GEMINAI_API_KEY, GEMINAI_MODEL, EMB
 app = FastAPI(title="Research Assistant API")
 
 ALLOWED_ORIGINS = [
+    "https://scholarsense-researchassistantai.netlify.app",
     "http://localhost",
     "http://localhost:80",
     "http://127.0.0.1",


### PR DESCRIPTION
Changed the frontend API base URL to point to the deployed backend. Added 'https://scholarsense-researchassistantai.netlify.app' to the list of allowed CORS origins in the backend to enable frontend-backend communication.